### PR TITLE
Elshan patch tolerations selector

### DIFF
--- a/templates/blackbox-exporter/deployment.yaml
+++ b/templates/blackbox-exporter/deployment.yaml
@@ -52,14 +52,14 @@ spec:
     {{- if .Values.blackbox.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.blackbox.nodeSelector | nindent 8 }}
-    {{- else }}
+    {{- else if.Values.global.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.global.nodeSelector | nindent 8 }}
     {{- end }}
     {{- if .Values.blackbox.tolerations }}
       tolerations:
         {{- toYaml .Values.blackbox.tolerations | nindent 8 }}
-    {{- else }}
+    {{- else if .Values.global.tolerations }}
       tolerations:
         {{- toYaml .Values.global.tolerations | nindent 8 }}
     {{- end }}

--- a/templates/blackbox-exporter/deployment.yaml
+++ b/templates/blackbox-exporter/deployment.yaml
@@ -49,15 +49,20 @@ spec:
             capabilities:
               drop:
                   - ALL
-    {{- if .Values.global.nodeSelector }}
+    {{- if .Values.blackbox.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.blackbox.nodeSelector | nindent 8 }}
+    {{- else }}
       nodeSelector:
         {{- toYaml .Values.global.nodeSelector | nindent 8 }}
     {{- end }}
-    {{- if .Values.global.tolerations }}
+    {{- if .Values.blackbox.tolerations }}
+      tolerations:
+        {{- toYaml .Values.blackbox.tolerations | nindent 8 }}
+    {{- else }}
       tolerations:
         {{- toYaml .Values.global.tolerations | nindent 8 }}
     {{- end }}
-      
       volumes:
         - name: config
           configMap:

--- a/templates/cadvisor/daemonset.yaml
+++ b/templates/cadvisor/daemonset.yaml
@@ -80,14 +80,14 @@ spec:
     {{- if .Values.cadvisor.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.cadvisor.nodeSelector | nindent 8 }}
-    {{- else }}
+    {{- else if .Values.global.nodeSelector }} 
       nodeSelector:
         {{- toYaml .Values.global.nodeSelector | nindent 8 }}
     {{- end }}
     {{- if .Values.cadvisor.tolerations }}
       tolerations:
         {{- toYaml .Values.cadvisor.tolerations | nindent 8 }}
-    {{- else }}
+    {{- else if .Values.global.tolerations }}
       tolerations:
         {{- toYaml .Values.global.tolerations | nindent 8 }}
     {{- end }}

--- a/templates/cadvisor/daemonset.yaml
+++ b/templates/cadvisor/daemonset.yaml
@@ -77,11 +77,17 @@ spec:
         hostPath:
           path: /var/lib/docker
 
-    {{- if .Values.global.nodeSelector }}
+    {{- if .Values.cadvisor.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.cadvisor.nodeSelector | nindent 8 }}
+    {{- else }}
       nodeSelector:
         {{- toYaml .Values.global.nodeSelector | nindent 8 }}
     {{- end }}
-    {{- if .Values.global.tolerations }}
+    {{- if .Values.cadvisor.tolerations }}
+      tolerations:
+        {{- toYaml .Values.cadvisor.tolerations | nindent 8 }}
+    {{- else }}
       tolerations:
         {{- toYaml .Values.global.tolerations | nindent 8 }}
     {{- end }}

--- a/templates/grafana/deployment.yaml
+++ b/templates/grafana/deployment.yaml
@@ -101,8 +101,6 @@ spec:
           {{- end }}
             - name: dashboards-alerts-gv
               mountPath: /etc/grafana/provisioning/dashboards/files/alerts
-            - name: dashboards-support-services
-              mountPath: /etc/grafana/provisioning/dashboards/files/sup-serv
             - name: storage
               mountPath:  /var/lib/grafana/data
             - name: config
@@ -137,11 +135,6 @@ spec:
       - name: dashboards-alerts-gv
         configMap:
           name: {{ .Release.Name }}-grafana-alert-folder-gv
-
-      - name: dashboards-support-services
-        configMap:
-          name: {{ .Release.Name }}-grafana-support-services
-
 
       - name: config
         configMap:
@@ -181,11 +174,17 @@ spec:
         emptyDir: {}
       {{- end }}
 
-    {{- if .Values.global.nodeSelector }}
+    {{- if .Values.grafana.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.grafana.nodeSelector | nindent 8 }}
+    {{- else }}
       nodeSelector:
         {{- toYaml .Values.global.nodeSelector | nindent 8 }}
     {{- end }}
-    {{- if .Values.global.tolerations }}
+    {{- if .Values.grafana.tolerations }}
+      tolerations:
+        {{- toYaml .Values.grafana.tolerations | nindent 8 }}
+    {{- else }}
       tolerations:
         {{- toYaml .Values.global.tolerations | nindent 8 }}
     {{- end }}

--- a/templates/grafana/deployment.yaml
+++ b/templates/grafana/deployment.yaml
@@ -101,6 +101,8 @@ spec:
           {{- end }}
             - name: dashboards-alerts-gv
               mountPath: /etc/grafana/provisioning/dashboards/files/alerts
+            - name: dashboards-support-services
+              mountPath: /etc/grafana/provisioning/dashboards/files/sup-serv
             - name: storage
               mountPath:  /var/lib/grafana/data
             - name: config
@@ -135,6 +137,11 @@ spec:
       - name: dashboards-alerts-gv
         configMap:
           name: {{ .Release.Name }}-grafana-alert-folder-gv
+
+      - name: dashboards-support-services
+        configMap:
+          name: {{ .Release.Name }}-grafana-support-services
+
 
       - name: config
         configMap:
@@ -173,18 +180,17 @@ spec:
       - name: storage
         emptyDir: {}
       {{- end }}
-
     {{- if .Values.grafana.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.grafana.nodeSelector | nindent 8 }}
-    {{- else }}
+    {{- else if .Values.global.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.global.nodeSelector | nindent 8 }}
     {{- end }}
     {{- if .Values.grafana.tolerations }}
       tolerations:
         {{- toYaml .Values.grafana.tolerations | nindent 8 }}
-    {{- else }}
+    {{- else if .Values.global.tolerations }}
       tolerations:
         {{- toYaml .Values.global.tolerations | nindent 8 }}
     {{- end }}

--- a/templates/kube-state-metrics/deployment.yaml
+++ b/templates/kube-state-metrics/deployment.yaml
@@ -54,14 +54,14 @@ spec:
     {{- if .Values.kubestatemetrics.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.kubestatemetrics.nodeSelector | nindent 8 }}
-    {{- else }}
+    {{- else if .Values.global.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.global.nodeSelector | nindent 8 }}
     {{- end }}
     {{- if .Values.kubestatemetrics.tolerations }}
       tolerations:
         {{- toYaml .Values.kubestatemetrics.tolerations | nindent 8 }}
-    {{- else }}
+    {{- else if .Values.global.tolerations }}
       tolerations:
         {{- toYaml .Values.global.tolerations | nindent 8 }}  
     {{- end }}

--- a/templates/kube-state-metrics/deployment.yaml
+++ b/templates/kube-state-metrics/deployment.yaml
@@ -51,11 +51,17 @@ spec:
             drop:
               - ALL
 
-    {{- if .Values.global.nodeSelector }}
+    {{- if .Values.kubestatemetrics.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.kubestatemetrics.nodeSelector | nindent 8 }}
+    {{- else }}
       nodeSelector:
         {{- toYaml .Values.global.nodeSelector | nindent 8 }}
     {{- end }}
-    {{- if .Values.global.tolerations }}
+    {{- if .Values.kubestatemetrics.tolerations }}
       tolerations:
-        {{- toYaml .Values.global.tolerations | nindent 8 }}
+        {{- toYaml .Values.kubestatemetrics.tolerations | nindent 8 }}
+    {{- else }}
+      tolerations:
+        {{- toYaml .Values.global.tolerations | nindent 8 }}  
     {{- end }}

--- a/templates/node-exporter/node-exporter.yaml
+++ b/templates/node-exporter/node-exporter.yaml
@@ -16,14 +16,14 @@ spec:
     {{- if .Values.nodexporter.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.nodexporter.nodeSelector | nindent 8 }}
-    {{- else }}
+    {{- else if .Values.global.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.global.nodeSelector | nindent 8 }}
     {{- end }}
     {{- if .Values.nodexporter.tolerations }}
       tolerations:
         {{- toYaml .Values.nodexporter.tolerations | nindent 8 }}
-    {{- else }}
+    {{- else if .Values.global.tolerations }}
       tolerations:
         {{- toYaml .Values.global.tolerations | nindent 8 }}
     {{- end }}

--- a/templates/node-exporter/node-exporter.yaml
+++ b/templates/node-exporter/node-exporter.yaml
@@ -13,11 +13,17 @@ spec:
       labels:
         app: {{ .Release.Name }}-node-exporter
     spec:
-    {{- if .Values.global.nodeSelector }}
+    {{- if .Values.nodexporter.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.nodexporter.nodeSelector | nindent 8 }}
+    {{- else }}
       nodeSelector:
         {{- toYaml .Values.global.nodeSelector | nindent 8 }}
     {{- end }}
-    {{- if .Values.global.tolerations }}
+    {{- if .Values.nodexporter.tolerations }}
+      tolerations:
+        {{- toYaml .Values.nodexporter.tolerations | nindent 8 }}
+    {{- else }}
       tolerations:
         {{- toYaml .Values.global.tolerations | nindent 8 }}
     {{- end }}

--- a/templates/postgresql/exporter.yaml
+++ b/templates/postgresql/exporter.yaml
@@ -82,14 +82,14 @@ spec:
     {{- if .Values.database.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.database.nodeSelector | nindent 8 }}
-    {{- else }}
+    {{- else if .Values.global.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.global.nodeSelector | nindent 8 }}
     {{- end }}
     {{- if .Values.database.tolerations }}
       tolerations:
         {{- toYaml .Values.database.tolerations | nindent 8 }}
-    {{- else }}
+    {{- else if .Values.global.tolerations }}
       tolerations:
         {{- toYaml .Values.global.tolerations | nindent 8 }}
     {{- end }}

--- a/templates/postgresql/exporter.yaml
+++ b/templates/postgresql/exporter.yaml
@@ -79,11 +79,17 @@ spec:
               drop:
                 - ALL
 
-    {{- if .Values.global.nodeSelector }}
+    {{- if .Values.database.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.database.nodeSelector | nindent 8 }}
+    {{- else }}
       nodeSelector:
         {{- toYaml .Values.global.nodeSelector | nindent 8 }}
     {{- end }}
-    {{- if .Values.global.tolerations }}
+    {{- if .Values.database.tolerations }}
+      tolerations:
+        {{- toYaml .Values.database.tolerations | nindent 8 }}
+    {{- else }}
       tolerations:
         {{- toYaml .Values.global.tolerations | nindent 8 }}
     {{- end }}

--- a/templates/prometheus/deployment.yaml
+++ b/templates/prometheus/deployment.yaml
@@ -153,14 +153,14 @@ spec:
     {{- if .Values.prometheus.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.prometheus.nodeSelector | nindent 8 }}
-    {{- else }}
+    {{- else if .Values.global.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.global.nodeSelector | nindent 8 }}
     {{- end }}
     {{- if .Values.prometheus.tolerations }}
       tolerations:
         {{- toYaml .Values.prometheus.tolerations | nindent 8 }}
-    {{- else }}
+    {{- else  if .Values.global.tolerations }}
       tolerations:
         {{- toYaml .Values.global.tolerations | nindent 8 }}
     {{- end }}

--- a/templates/prometheus/deployment.yaml
+++ b/templates/prometheus/deployment.yaml
@@ -150,11 +150,17 @@ spec:
         emptyDir: {}
       {{- end }}
 
-    {{- if .Values.global.nodeSelector }}
+    {{- if .Values.prometheus.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.prometheus.nodeSelector | nindent 8 }}
+    {{- else }}
       nodeSelector:
         {{- toYaml .Values.global.nodeSelector | nindent 8 }}
     {{- end }}
-    {{- if .Values.global.tolerations }}
+    {{- if .Values.prometheus.tolerations }}
+      tolerations:
+        {{- toYaml .Values.prometheus.tolerations | nindent 8 }}
+    {{- else }}
       tolerations:
         {{- toYaml .Values.global.tolerations | nindent 8 }}
     {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -30,15 +30,51 @@ networkPolicy:
 clusterRoleAccess:
   enabled: true
  
-
 global:
   storageClassName: "default"
   nodeSelector: {}
     # node.kubernetes.io/instance-type: "demo"
   tolerations: []
-    # - key: beta.kubernetes.io/instance-type
+    # - key: istanbul.kubernetes.io/instance-type
     #   operator: "Exists"
     #   effect: "NoSchedule"
+
+
+nodexporter:
+  nodeSelector: {}
+     #node.kubernetes.io/instance-type: "demo"
+  tolerations: []
+     #- key: iomete.kubernetes.io/instance-type
+     #  operator: "Exists"
+     #  effect: "NoSchedule"
+    
+blackbox:
+  nodeSelector: {}
+     #node.kubernetes.io/instance-type: "demo"
+  tolerations: []
+     #- key: iomete.kubernetes.io/instance-type
+     #  operator: "Exists"
+     #  effect: "NoSchedule"
+    #
+cadvisor:
+  nodeSelector: {}
+     #node.kubernetes.io/instance-type: "demo"
+  tolerations: []
+     #- key: iomete.kubernetes.io/instance-type
+     #  operator: "Exists"
+     #  effect: "NoSchedule"
+
+kubestatemetrics:
+  nodeSelector: {}
+     #node.kubernetes.io/instance-type: "demo"
+  tolerations: []
+     #- key: iomete.kubernetes.io/instance-type
+     #  operator: "Exists"
+     #  effect: "NoSchedule"
+
+
+
+
 
 # -- Grafana configuration
 grafana:
@@ -53,6 +89,12 @@ grafana:
   # -- Admin password (change in production)
   # @required
   adminPassword: "admin"
+  nodeSelector: {}
+    #node.kubernetes.io/instance-type: "demo"
+  tolerations: []
+   #- key: istanbul.kubernetes.io/instance-type
+   #  operator: "Exists"
+   #  effect: "NoSchedule"
   
   alerting:
     enabled: false
@@ -128,7 +170,7 @@ grafana:
         alertSeverity: "critical"
         datasourceUid: "Prometheus"
         alertTimeRangeFrom: 300
-        dashboardUid: "lrsr"
+        dashboardUid: "serv-avail"
         panelId: "3"
       
       highFailedTasks:
@@ -144,7 +186,7 @@ grafana:
         thresholdValue: 10
         duration: "30m"
         datasourceUid: "Prometheus"
-        dashboardUid: "lrsr"
+        dashboardUid: "serv-avail"
         panelId: "4"
       
       lowTaskSuccessRate:
@@ -159,7 +201,7 @@ grafana:
         alertTimeRangeFrom: 300
         thresholdValue: 90
         datasourceUid: "Prometheus"
-        dashboardUid: "lrsr"
+        dashboardUid: "serv-avail"
         panelId: "5"
       
       serviceAvailability:
@@ -202,7 +244,7 @@ grafana:
         thresholdValue: 500
         duration: "10m"
         datasourceUid: "Prometheus"
-        dashboardUid: "lrsr"
+        dashboardUid: "serv-avail"
         panelId: "10"
       
       frequentGcAlert:
@@ -219,7 +261,7 @@ grafana:
         thresholdValue: 30
         duration: "10m"
         datasourceUid: "Prometheus"
-        dashboardUid: "lrsr"
+        dashboardUid: "serv-avail"
         panelId: "7"
       
       majorGcAlert:
@@ -235,7 +277,7 @@ grafana:
         thresholdValue: 30
         duration: "10m"
         datasourceUid: "Prometheus"
-        dashboardUid: "lrsr"
+        dashboardUid: "serv-avail"
         panelId: "8"
       
       heapMemoryAlert:
@@ -255,7 +297,7 @@ grafana:
         thresholdValue: 85
         duration: "10m"
         datasourceUid: "Prometheus"
-        dashboardUid: "lrsr"
+        dashboardUid: "serv-avail"
         panelId: "12"
       
       jobSuccessRateAlert:
@@ -277,7 +319,7 @@ grafana:
         thresholdValue: 90
         duration: "10m"
         datasourceUid: "Prometheus"
-        dashboardUid: "lrsr"
+        dashboardUid: "serv-avail"
         panelId: "9"
   
   # -- Additional environment variables
@@ -342,10 +384,13 @@ prometheus:
     replicas: 1
   
   # -- Node affinity configuration
-  affinity: { }
-  
-  # -- Node tolerations
+  nodeSelector: {}
+     #node.kubernetes.io/instance-type: "demo"
   tolerations: []
+     #- key: iomete.kubernetes.io/instance-type
+     #  operator: "Exists"
+     #  effect: "NoSchedule"
+
   
   # -- Persistence configuration
   persistence:
@@ -389,13 +434,15 @@ prometheus:
 ## Service will be available but most features will not work properly
 
 loki:
-  enabled: false
+  enabled: true
   
   # -- Configuration for the Loki service
   loki:
   ### -- Loki configuration
   ## Dont change this unless you know what you are doing
     auth_enabled: false
+    limits_config:
+      max_label_names_per_series: 25
     replication_factor: 1
     schemaConfig:
       configs:
@@ -421,7 +468,10 @@ loki:
         secretAccessKey: secretKey
         accessKeyId: accessKey
         s3ForcePathStyle: true
-        insecure: false
+        insecure: false #if you want nosecure,you should do  insecure true,uncomment http_config
+        #http_config:
+        #    insecure_skip_verify: true
+
     ingester:
       chunk_encoding: snappy
     tracing:
@@ -429,6 +479,24 @@ loki:
     querier:
       # Default is 4, if you have enough memory and CPU you can increase, reduce if OOMing
       max_concurrent: 2
+
+  lokiCanary:
+    enabled: true
+    nodeSelector: {}
+      #node.kubernetes.io/instance-type: "demo"
+    tolerations: []
+     #- key: iomete.kubernetes.io/instance-type
+     #  operator: "Exists"
+     #  effect: "NoSchedule"
+  gateway:
+    enabled: true
+    replicas: 1
+    nodeSelector: {}
+      #node.kubernetes.io/instance-type: "demo"
+    tolerations: []
+     #- key: iomete.kubernetes.io/instance-type
+     #  operator: "Exists"
+     #  effect: "NoSchedule"
   deploymentMode: SingleBinary
   singleBinary:
     replicas: 2
@@ -439,6 +507,12 @@ loki:
       requests:
         cpu: 2
         memory: 2Gi
+    nodeSelector: {}
+      #node.kubernetes.io/instance-type: "demo"
+    tolerations: []
+     #- key: iomete.kubernetes.io/instance-type
+     #  operator: "Exists"
+     #  effect: "NoSchedule"
     extraEnv:
       # Keep a little bit lower than memory limits
       - name: GOMEMLIMIT
@@ -505,6 +579,13 @@ loki:
 # -- Database configuration
 database:
   enabled: false
+  nodeSelector: {}
+    #node.kubernetes.io/instance-type: "demo"
+  tolerations: []
+  #- key: iomete.kubernetes.io/instance-type
+  #  operator: "Exists"
+  #  effect: "NoSchedule"
+
   # -- PostgreSQL host
   # @required
   host: "postgresql"
@@ -543,3 +624,14 @@ typesenseExporter:
     apiKey: "Rhsdhas2asasdasj2"
     service: "typesense"
     port: "80"
+
+
+promtail:
+  enabled: true
+  nodeSelector: {}
+    #node.kubernetes.io/instance-type: "demo"
+  tolerations: []
+    # - key: istanbul.kubernetes.io/instance-type
+    #   operator: "Exists"
+    #   effect: "NoSchedule"
+


### PR DESCRIPTION
- Refactored the `nodeSelector` and `tolerations` configuration to be more flexible.
- Added fallback logic for `nodeSelector` in case it’s not set globally.
- Updated `cadvisor`, `blackbox`, and `nodexporter` components to use default `nodeSelector` if not defined.
- Corrected missing tolerations for the `promtail` component that was preventing proper scheduling.
